### PR TITLE
Fix video-loading regressions found in code review

### DIFF
--- a/__tests__/src/components/AnnotationsOverlayVideo.test.jsx
+++ b/__tests__/src/components/AnnotationsOverlayVideo.test.jsx
@@ -1,0 +1,52 @@
+import { render } from '@tests/utils/test-utils';
+import { AnnotationsOverlayVideo } from '../../../src/components/AnnotationsOverlayVideo';
+import CanvasWorld from '../../../src/lib/CanvasWorld';
+
+vi.mock('../../../src/lib/CanvasOverlayVideo', () => ({
+  default: class MockCanvasOverlayVideo {
+    constructor() {
+      this.canvas = null;
+    }
+  },
+}));
+
+vi.mock('react-resize-observer', () => ({ default: () => null }));
+
+/** create wrapper */
+function createWrapper(props) {
+  const canvasWorld = new CanvasWorld([]);
+  canvasWorld.canvasToWorldCoordinates = vi.fn(() => [0, 0, 100, 100]);
+
+  return render(
+    <AnnotationsOverlayVideo
+      canvas={{ id: 'canvas1' }}
+      canvasWorld={canvasWorld}
+      debug={false}
+      iiifVideoInfos={{}}
+      onFunctionsReady={() => {}}
+      playerRef={{}}
+      videoRef={document.createElement('video')}
+      windowId="window1"
+      {...props}
+    />,
+  );
+}
+
+describe('AnnotationsOverlayVideo', () => {
+  it('removes every video event listener it registered on mount, using the same handler reference, when it unmounts', () => {
+    const videoRef = document.createElement('video');
+    const addSpy = vi.spyOn(videoRef, 'addEventListener');
+    const removeSpy = vi.spyOn(videoRef, 'removeEventListener');
+
+    const { unmount } = createWrapper({ videoRef });
+
+    const addedListeners = addSpy.mock.calls.map(([type, handler]) => ({ handler, type }));
+    expect(addedListeners.length).toBeGreaterThan(0);
+
+    unmount();
+
+    addedListeners.forEach(({ type, handler }) => {
+      expect(removeSpy).toHaveBeenCalledWith(type, handler);
+    });
+  });
+});

--- a/__tests__/src/components/VideoViewer.test.jsx
+++ b/__tests__/src/components/VideoViewer.test.jsx
@@ -1,58 +1,113 @@
+import { forwardRef, useImperativeHandle } from 'react';
+import PropTypes from 'prop-types';
 import { render, screen } from '@tests/utils/test-utils';
 import { VideoViewer } from '../../../src/components/VideoViewer';
 
+const { mockGetInternalPlayer, mockSeekTo } = vi.hoisted(() => ({
+  mockGetInternalPlayer: vi.fn(() => ({})),
+  mockSeekTo: vi.fn(),
+}));
+
+vi.mock('@celluloid/react-player', () => {
+  /** Stub replacing the real player so tests don't depend on real media playback. */
+  const MockReactPlayer = forwardRef(({ url }, ref) => {
+    useImperativeHandle(ref, () => ({
+      getInternalPlayer: mockGetInternalPlayer,
+      seekTo: mockSeekTo,
+    }));
+    return <div data-testid="react-player" data-url={url} />;
+  });
+  MockReactPlayer.propTypes = { url: PropTypes.string.isRequired };
+  MockReactPlayer.displayName = 'MockReactPlayer';
+  return { default: MockReactPlayer };
+});
+
+vi.mock('react-resize-observer', () => ({ default: () => null }));
+
+vi.mock('../../../src/containers/AnnotationsOverlayVideo', () => ({
+  default: () => <div data-testid="annotations-overlay-video-mock" />,
+}));
+
+vi.mock('../../../src/containers/WindowCanvasNavigationControlsVideo', () => ({
+  default: () => <div data-testid="window-canvas-navigation-controls-video-mock" />,
+}));
+
+/** Builds a stub canvas exposing only what VideoViewer reads from it. */
+function buildCanvas(annotations = [], duration = 0) {
+  return {
+    getContent: () => annotations,
+    getDuration: () => duration,
+  };
+}
+
+/** Builds a stub annotation with a Video body, optionally restricted to a temporal fragment. */
+function buildVideoAnnotation({ start, end, id = 'https://example.org/video.mp4', width = 640, height = 480 } = {}) {
+  const fragment = typeof start === 'number' ? `#t=${start}${typeof end === 'number' ? `,${end}` : ''}` : '';
+  return {
+    __jsonld: { target: `https://example.org/canvas1${fragment}` },
+    getBody: () => [
+      {
+        __jsonld: { id, type: 'Video' },
+        getHeight: () => height,
+        getWidth: () => width,
+        id,
+      },
+    ],
+  };
+}
+
 /** create wrapper */
-function createWrapper(props, suspenseFallback) {
-  return render(<VideoViewer classes={{}} videoOptions={{ crossOrigin: 'anonymous', 'data-testid': 'video' }} {...props} />);
+function createWrapper(props) {
+  return render(<VideoViewer debug={false} setSeekTo={() => {}} windowId="window1" {...props} />);
 }
 
 describe('VideoViewer', () => {
+  beforeEach(() => {
+    mockSeekTo.mockClear();
+  });
+
   describe('render', () => {
-    it.skip('videoResources', () => {
-      createWrapper(
-        {
-          videoResources: [
-            { getFormat: () => 'video/mp4', id: 1 },
-            { getFormat: () => 'video/mp4', id: 2 },
-          ],
-        },
-        true,
-      );
-      const video = screen.getByTestId('video');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('source:nth-of-type(1)')).toHaveAttribute('type', 'video/mp4');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('source:nth-of-type(2)')).toHaveAttribute('type', 'video/mp4');
+    it('renders nothing when the canvas has no video content', () => {
+      createWrapper({ canvas: buildCanvas([]) });
+
+      expect(screen.queryByTestId('react-player')).not.toBeInTheDocument();
     });
-    it.skip('passes through configurable options', () => {
-      createWrapper(
-        {
-          videoResources: [{ getFormat: () => 'video/mp4', id: 1 }],
-        },
-        true,
-      );
-      expect(screen.getByTestId('video')).toHaveAttribute('crossOrigin', 'anonymous');
+
+    it('renders the player for the canvas video resource', () => {
+      createWrapper({ canvas: buildCanvas([buildVideoAnnotation()]) });
+
+      expect(screen.getByTestId('react-player')).toHaveAttribute('data-url', 'https://example.org/video.mp4');
     });
-    it.skip('captions', () => {
-      createWrapper(
-        {
-          captions: [
-            { getDefaultLabel: () => 'English', getProperty: () => 'en', id: 1 },
-            { getDefaultLabel: () => 'French', getProperty: () => 'fr', id: 2 },
-          ],
-          videoResources: [{ getFormat: () => 'video/mp4', id: 1 }],
-        },
-        true,
-      );
-      const video = screen.getByTestId('video');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('track:nth-of-type(1)')).toHaveAttribute('srcLang', 'en');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('track:nth-of-type(1)')).toHaveAttribute('label', 'English');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('track:nth-of-type(2)')).toHaveAttribute('srcLang', 'fr');
-      // eslint-disable-next-line testing-library/no-node-access
-      expect(video.querySelector('track:nth-of-type(2)')).toHaveAttribute('label', 'French');
+
+    it('does not render a player when currentTime falls outside the annotation temporal fragment', () => {
+      createWrapper({
+        canvas: buildCanvas([buildVideoAnnotation({ end: 200, start: 100 })]),
+        currentTime: 0,
+      });
+
+      expect(screen.queryByTestId('react-player')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('componentDidUpdate', () => {
+    it('does not crash seeking when currentTime changes while no player is mounted', () => {
+      const canvas = buildCanvas([buildVideoAnnotation({ end: 200, start: 100 })]);
+      const { rerender } = createWrapper({ canvas, currentTime: 0, paused: true });
+
+      expect(screen.queryByTestId('react-player')).not.toBeInTheDocument();
+
+      expect(() =>
+        rerender(<VideoViewer canvas={canvas} currentTime={5} debug={false} paused setSeekTo={() => {}} windowId="window1" />),
+      ).not.toThrow();
+    });
+
+    it('seeks the mounted player when currentTime changes while paused', () => {
+      const canvas = buildCanvas([buildVideoAnnotation()]);
+      const { rerender } = createWrapper({ canvas, currentTime: 0, paused: true });
+
+      rerender(<VideoViewer canvas={canvas} currentTime={5} debug={false} paused setSeekTo={() => {}} windowId="window1" />);
+
+      expect(mockSeekTo).toHaveBeenCalledWith(5);
     });
   });
 });

--- a/__tests__/src/components/WindowCanvasNavigationControlsVideo.test.jsx
+++ b/__tests__/src/components/WindowCanvasNavigationControlsVideo.test.jsx
@@ -1,0 +1,38 @@
+import { render } from '@tests/utils/test-utils';
+import { WindowCanvasNavigationControlsVideo } from '../../../src/components/WindowCanvasNavigationControlsVideo';
+import ns from '../../../src/config/css-ns';
+
+vi.mock('../../../src/containers/ViewerInfo', () => ({ default: () => null }));
+vi.mock('../../../src/containers/ViewerNavigation', () => ({ default: () => null }));
+vi.mock('../../../src/containers/ViewerNavigationVideo', () => ({ default: () => null }));
+
+const stackedClass = ns('canvas-nav-stacked');
+
+/** create wrapper */
+function createWrapper(props) {
+  return render(<WindowCanvasNavigationControlsVideo windowId="window1" {...props} />);
+}
+
+describe('WindowCanvasNavigationControlsVideo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stacks the controls when it measures its own container as narrower than the breakpoint', () => {
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({ height: 40, width: 200 });
+
+    const { container } = createWrapper();
+
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    expect(container.querySelector(`.${stackedClass}`)).toBeInTheDocument();
+  });
+
+  it('does not stack the controls when it measures its own container as wider than the breakpoint', () => {
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({ height: 40, width: 400 });
+
+    const { container } = createWrapper();
+
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+    expect(container.querySelector(`.${stackedClass}`)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AnnotationsOverlayVideo.jsx
+++ b/src/components/AnnotationsOverlayVideo.jsx
@@ -252,11 +252,10 @@ export class AnnotationsOverlayVideo extends Component {
       this.resizeObserver.disconnect();
     }
     if (this.video) {
-      // this.video.removeEventListener('timeupdate', this.onVideoTimeUpdate);
-      // this.video.removeEventListener('loadedmetadata', this.onVideoLoadedMetadata);
-      // this.video.removeEventListener('waiting', this.onVideoWaiting);
-      // this.video.removeEventListener('playing', this.onVideoPlaying);
-      // this.video.removeEventListener('seeked', this.onVideoPlaying);
+      this.video.removeEventListener('timeupdate', this.onVideoTimeUpdate);
+      this.video.removeEventListener('loadedmetadata', this.onVideoLoadedMetadata);
+      this.video.removeEventListener('waiting', this.onVideoWaiting);
+      this.video.removeEventListener('seeked', this.onVideoPlaying);
     }
     if (this.canvasOverlay && this.canvasOverlay.canvas) {
       this.canvasOverlay.canvas.removeEventListener('click', this.onCanvasClick);
@@ -715,7 +714,7 @@ AnnotationsOverlayVideo.propTypes = {
   hoveredAnnotationIds: PropTypes.arrayOf(PropTypes.string),
   // iiifVideoInfos is used by plugin by ref
   iiifVideoInfos: PropTypes.object.isRequired,
-  onFunctionsReady: PropTypes.object.isRequired,
+  onFunctionsReady: PropTypes.func.isRequired,
   palette: PropTypes.object,
   paused: PropTypes.bool,
   playerRef: PropTypes.object.isRequired,

--- a/src/components/VideoViewer.jsx
+++ b/src/components/VideoViewer.jsx
@@ -1,5 +1,3 @@
-import flatten from 'lodash/flatten';
-import flattenDeep from 'lodash/flattenDeep';
 import { createRef, Component } from 'react';
 import PropTypes from 'prop-types';
 import * as ResizeObserverModule from 'react-resize-observer';
@@ -45,7 +43,7 @@ export class VideoViewer extends Component {
 
   /** */
   componentDidUpdate(prevProps) {
-    const { canvas, currentTime, paused, setCurrentTime, setPaused, windowId, setSeekTo } = this.props;
+    const { canvas, currentTime, paused, setCurrentTime, setPaused, setSeekTo } = this.props;
     if (paused !== prevProps.paused) {
       if (paused) {
         this.timerStop();
@@ -56,7 +54,7 @@ export class VideoViewer extends Component {
     // Ensure `currentTime` updates are consistent
     if (currentTime !== prevProps.currentTime) {
       // Fix issue where reactPlayer didn't populate seek to time when the time was at 0
-      if (prevProps.currentTime === 0 || paused === true) {
+      if ((prevProps.currentTime === 0 || paused === true) && this.playerRef.current) {
         this.playerRef.current.seekTo(currentTime);
       }
     }
@@ -119,25 +117,24 @@ export class VideoViewer extends Component {
 
     const { containerRatio } = this.state;
 
-    const videoResources = flatten(
-      flattenDeep([
-        canvas.getContent().map((annot) => {
-          const annotaion = new AnnotationItem(annot.__jsonld);
-          const temporalfragment = annotaion.temporalfragmentSelector;
-          if (temporalfragment && temporalfragment.length > 0) {
-            const start = temporalfragment[0] || 0;
-            const end = temporalfragment.length > 1 ? temporalfragment[1] : Number.MAX_VALUE;
-            if (start <= currentTime && currentTime < end) {
-              //
-            } else {
-              return {};
-            }
+    const videoResources = canvas
+      .getContent()
+      .map((annot) => {
+        const annotaion = new AnnotationItem(annot.__jsonld);
+        const temporalfragment = annotaion.temporalfragmentSelector;
+        if (temporalfragment && temporalfragment.length > 0) {
+          const start = temporalfragment[0] || 0;
+          const end = temporalfragment.length > 1 ? temporalfragment[1] : Number.MAX_VALUE;
+          if (start <= currentTime && currentTime < end) {
+            //
+          } else {
+            return {};
           }
-          const body = annot.getBody();
-          return { body, temporalfragment };
-        }),
-      ]).filter((resource) => resource.body && resource.body[0].__jsonld && resource.body[0].__jsonld.type === 'Video'),
-    );
+        }
+        const body = annot.getBody();
+        return { body, temporalfragment };
+      })
+      .filter((resource) => resource.body && resource.body[0].__jsonld && resource.body[0].__jsonld.type === 'Video');
 
     // Only one video can be displayed at a time in this implementation.
     const len = videoResources.length;

--- a/src/components/WindowCanvasNavigationControlsVideo.jsx
+++ b/src/components/WindowCanvasNavigationControlsVideo.jsx
@@ -3,25 +3,43 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import * as ResizeObserverModule from 'react-resize-observer';
 import ViewerInfo from '../containers/ViewerInfo';
 import ViewerNavigation from '../containers/ViewerNavigation';
 import ViewerNavigationVideo from '../containers/ViewerNavigationVideo';
 import ns from '../config/css-ns';
 import { PluginHook } from './PluginHook';
+import unwrapDefault from '../lib/unwrapDefault';
+
+// Some bundler/CJS-interop combinations (notably esbuild's dependency
+// pre-bundling in Vite dev mode) leave this double-wrapped as
+// { default: { default: Component } } instead of unwrapping to Component.
+const ResizeObserver = unwrapDefault(ResizeObserverModule);
 
 /**
  * WindowCanvasNavigationControlsVideo - based on WindowCanvasNavigationControls
  * Represents the viewer controls in the mirador workspace.
  */
 export class WindowCanvasNavigationControlsVideo extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+    this.state = { size: {} };
+  }
+
   /**
    * Determine if canvasNavControls are stacked (based on a hard-coded width)
    */
   canvasNavControlsAreStacked() {
-    const { size } = this.props;
+    const { size } = this.state;
 
     return size && size.width && size.width <= 253;
   }
+
+  /** */
+  setSize = (size) => {
+    this.setState({ size });
+  };
 
   /** */
   render() {
@@ -49,11 +67,12 @@ export class WindowCanvasNavigationControlsVideo extends Component {
           zIndex: 50,
         })}
       >
+        <ResizeObserver onResize={this.setSize} />
         <ViewerNavigation windowId={windowId} beforeClick={setPaused} />
         <ViewerInfo windowId={windowId} />
         <ViewerNavigationVideo windowId={windowId} />
 
-        <PluginHook {...this.props} />
+        <PluginHook {...this.props} size={this.state.size} />
       </Paper>
     );
   }
@@ -62,7 +81,6 @@ export class WindowCanvasNavigationControlsVideo extends Component {
 WindowCanvasNavigationControlsVideo.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string),
   setPaused: PropTypes.func,
-  size: PropTypes.shape({ width: PropTypes.number }).isRequired,
   visible: PropTypes.bool,
   windowId: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## Summary
- `VideoViewer`: guard `componentDidUpdate`'s `seekTo` call against a null `playerRef`, which crashed whenever `currentTime` changed while no video was visible (e.g. before a temporal-fragment clip starts); also drop a redundant double lodash `flatten` and an unused `windowId` destructure.
- `AnnotationsOverlayVideo`: restore the `componentWillUnmount` cleanup for video event listeners (commented out during a past merge), which was leaking `timeupdate`/`loadedmetadata`/`waiting`/`seeked` listeners on every canvas switch; fix `onFunctionsReady` PropTypes (`object` -> `func`).
- `WindowCanvasNavigationControlsVideo`: measure its own container via `react-resize-observer` instead of relying on a `size` prop nobody ever supplied, restoring the narrow-window stacked layout.
- Adds regression tests for all three components — previously the only video-viewer test file was fully skipped and stale against the current props API.

Originated from a `/code-review` pass over the video-loading stack starting at `VideoViewer.jsx`.

## Test plan
- [x] `npx vitest run __tests__/src/components/VideoViewer.test.jsx __tests__/src/components/AnnotationsOverlayVideo.test.jsx __tests__/src/components/WindowCanvasNavigationControlsVideo.test.jsx` — 8/8 passing
- [x] `npx eslint` on all changed files — clean
- [ ] `npm test` (full gate: build && lint && size && vitest) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)